### PR TITLE
Update to Kubernetes v1.12

### DIFF
--- a/kovh/data/k8s/addons/flannel.yml
+++ b/kovh/data/k8s/addons/flannel.yml
@@ -116,6 +116,9 @@ spec:
       - key: node-role.kubernetes.io/master
         operator: Exists
         effect: NoSchedule
+      - key: node.kubernetes.io/not-ready
+        operator: Exists
+        effect: NoSchedule
       serviceAccountName: flannel
       initContainers:
       - name: install-cni

--- a/kovh/data/k8s/addons/kubedns.yml
+++ b/kovh/data/k8s/addons/kubedns.yml
@@ -91,7 +91,7 @@ spec:
           optional: true
       containers:
       - name: kubedns
-        image: k8s.gcr.io/k8s-dns-kube-dns-amd64:1.14.10
+        image: k8s.gcr.io/k8s-dns-kube-dns-amd64:1.14.13
         resources:
           # TODO: Set memory limits when we've profiled the container for large
           # clusters, then set request = limit to keep this container in
@@ -142,7 +142,7 @@ spec:
         - name: kube-dns-config
           mountPath: /kube-dns-config
       - name: dnsmasq
-        image: k8s.gcr.io/k8s-dns-dnsmasq-nanny-amd64:1.14.10
+        image: k8s.gcr.io/k8s-dns-dnsmasq-nanny-amd64:1.14.13
         livenessProbe:
           httpGet:
             path: /healthcheck/dnsmasq
@@ -181,7 +181,7 @@ spec:
         - name: kube-dns-config
           mountPath: /etc/k8s/dns/dnsmasq-nanny
       - name: sidecar
-        image: k8s.gcr.io/k8s-dns-sidecar-amd64:1.14.10
+        image: k8s.gcr.io/k8s-dns-sidecar-amd64:1.14.13
         livenessProbe:
           httpGet:
             path: /metrics

--- a/kovh/data/k8s/kubecontrollermanagerconfig.json
+++ b/kovh/data/k8s/kubecontrollermanagerconfig.json
@@ -1,0 +1,26 @@
+{
+  "apiVersion": "kubecontrollermanager.config.k8s.io/v1alpha1",
+  "kind": "KubeControllerManagerConfiguration",
+  "generic": {
+    "address": "127.0.0.1",
+    "clientConnection": {
+      "kubeconfig": "/etc/kubernetes/kubeconfig"
+    }
+  },
+  "kubeCloudShared": {
+    "allocateNodeCIDRs": true,
+    "clusterCIDR": "172.17.0.0/16",
+    "useServiceAccountCredentials": true
+  },
+  "nodeIPAMController": {
+    "serviceCIDR": "10.0.0.0/16"
+  },
+  "csrSigningController": {
+    "clusterSigningCertFile": "/etc/kubernetes/tls/ca.pem",
+    "clusterSigningKeyFile": "/etc/kubernetes/tls/ca.key"
+  },
+  "saController": {
+    "rootCAFile": "/etc/kubernetes/tls/ca.pem",
+    "serviceAccountKeyFile": "/etc/kubernetes/tls/host.key"
+  }
+}

--- a/kovh/data/k8s/kubeletconfig.json
+++ b/kovh/data/k8s/kubeletconfig.json
@@ -1,0 +1,29 @@
+{
+  "apiVersion": "kubelet.config.k8s.io/v1beta1",
+  "kind": "KubeletConfiguration",
+  "port": 10250,
+  "readOnlyPort": 0,
+  "healthzBindAddress": "127.0.0.1",
+  "healthzPort": 10248,
+  "staticPodPath": "/etc/kubernetes/manifests",
+  "clusterDomain": "cluster.local",
+  "clusterDNS": [
+    "10.0.0.10"
+  ],
+  "tlsCertFile": "/etc/kubernetes/tls/server/kubeletbundle.crt",
+  "tlsPrivateKeyFile": "/etc/kubernetes/tls/host.key",
+  "authentication": {
+    "x509": {
+      "clientCAFile": "/etc/kubernetes/tls/ca.pem"
+    },
+    "webhook": {
+      "enabled": true
+    },
+    "anonymous": {
+      "enabled": false
+    }
+  },
+  "authorization": {
+    "mode": "Webhook"
+  }
+}

--- a/kovh/data/k8s/kubeproxyconfig.json
+++ b/kovh/data/k8s/kubeproxyconfig.json
@@ -1,0 +1,10 @@
+{
+  "apiVersion": "kubeproxy.config.k8s.io/v1alpha1",
+  "kind": "KubeProxyConfiguration",
+  "clusterCIDR": "172.17.0.0/16",
+  "healthzBindAddress": "127.0.0.1",
+  "mode": "iptables",
+  "clientConnection": {
+    "kubeconfig": "/etc/kubernetes/kubeconfig"
+  }
+}

--- a/kovh/data/k8s/kubeschedulerconfig.json
+++ b/kovh/data/k8s/kubeschedulerconfig.json
@@ -1,0 +1,8 @@
+{
+  "apiVersion": "kubescheduler.config.k8s.io/v1alpha1",
+  "type": "KubeSchedulerConfiguration",
+  "healthzBindAddress": "127.0.0.1",
+  "clientConnection": {
+    "kubeconfig": "/etc/kubernetes/kubeconfig"
+  }
+}

--- a/kovh/data/k8s/manifests/kube-addon-manager.yml
+++ b/kovh/data/k8s/manifests/kube-addon-manager.yml
@@ -13,7 +13,7 @@ spec:
   hostNetwork: true
   containers:
   - name: kube-addon-manager
-    image: k8s.gcr.io/kube-addon-manager:v8.6
+    image: k8s.gcr.io/kube-addon-manager:v8.7
     resources:
       requests:
         cpu: 5m

--- a/kovh/data/k8s/manifests/kube-controller-manager.json
+++ b/kovh/data/k8s/manifests/kube-controller-manager.json
@@ -48,6 +48,11 @@
         },
         "volumeMounts": [
           {
+            "mountPath": "/etc/kubernetes/kubecontrollermanagerconfig",
+            "name": "config",
+            "readOnly": true
+          },
+          {
             "mountPath": "/etc/kubernetes/kubeconfig",
             "name": "kubeconfig",
             "readOnly": true
@@ -71,6 +76,12 @@
       }
     ],
     "volumes": [
+      {
+        "hostPath": {
+          "path": "/etc/kubernetes/kubecontrollermanagerconfig"
+        },
+        "name": "config"
+      },
       {
         "hostPath": {
           "path": "/etc/kubernetes/kubeconfig-controller-manager"

--- a/kovh/data/k8s/manifests/kube-proxy.json
+++ b/kovh/data/k8s/manifests/kube-proxy.json
@@ -13,11 +13,7 @@
         "image": "__IMAGE__",
         "command": [
           "kube-proxy",
-          "--cluster-cidr=172.17.0.0/16",
-          "--healthz-bind-address=127.0.0.1",
-          "--proxy-mode=iptables",
-          "--kubeconfig=/etc/kubernetes/kubeconfig",
-          "--profiling=false"
+          "--config=/etc/kubernetes/kubeproxyconfig"
         ],
         "securityContext": {
           "privileged": true
@@ -38,6 +34,11 @@
           "timeoutSeconds": 15
         },
         "volumeMounts": [
+          {
+            "mountPath": "/etc/kubernetes/kubeproxyconfig",
+            "name": "config",
+            "readOnly": true
+          },
           {
             "mountPath": "/etc/kubernetes/kubeconfig",
             "name": "kubeconfig",
@@ -67,6 +68,12 @@
       }
     ],
     "volumes": [
+      {
+        "hostPath": {
+          "path": "/etc/kubernetes/kubeproxyconfig"
+        },
+        "name": "config"
+      },
       {
         "hostPath": {
           "path": "/etc/kubernetes/kubeconfig-proxy"

--- a/kovh/data/k8s/manifests/kube-scheduler.json
+++ b/kovh/data/k8s/manifests/kube-scheduler.json
@@ -13,9 +13,7 @@
         "image": "__IMAGE__",
         "command": [
           "kube-scheduler",
-          "--address=127.0.0.1",
-          "--kubeconfig=/etc/kubernetes/kubeconfig",
-          "--profiling=false"
+          "--config=/etc/kubernetes/kubeschedulerconfig"
         ],
         "resources": {
           "requests": {
@@ -38,6 +36,11 @@
           "timeoutSeconds": 15
         },
         "volumeMounts": [
+          {
+            "mountPath": "/etc/kubernetes/kubeschedulerconfig",
+            "name": "config",
+            "readOnly": true
+          },
           {
             "mountPath": "/etc/kubernetes/kubeconfig",
             "name": "kubeconfig",
@@ -62,6 +65,12 @@
       }
     ],
     "volumes": [
+      {
+        "hostPath": {
+          "path": "/etc/kubernetes/kubeschedulerconfig"
+        },
+        "name": "config"
+      },
       {
         "hostPath": {
           "path": "/etc/kubernetes/kubeconfig-scheduler"

--- a/kovh/data/systemd/kubelet.service
+++ b/kovh/data/systemd/kubelet.service
@@ -9,6 +9,7 @@ After=coreos-metadata.service
 Restart=on-failure
 RestartSec=10s
 TimeoutStartSec=0
+WorkingDirectory=/etc/kubernetes
 
 EnvironmentFile=/run/metadata/coreos
 Environment="KUBELET_IMAGE_URL=docker://k8s.gcr.io/hyperkube"
@@ -16,27 +17,20 @@ Environment="KUBELET_IMAGE_TAG=__IMAGE_TAG__"
 Environment="RKT_GLOBAL_ARGS=--insecure-options=image"
 Environment="RKT_RUN_ARGS=--uuid-file-save=/var/lib/coreos/kubelet-wrapper.uuid --hosts-entry=host --dns=host --volume cniconf,kind=host,source=/etc/cni/net.d,readOnly=true --mount volume=cniconf,target=/etc/cni/net.d"
 
-ExecStartPre=/usr/bin/gunzip -r /etc/kubernetes
 ExecStartPre=/usr/bin/mkdir --parents /var/lib/coreos
 ExecStartPre=/usr/bin/mkdir --parents /etc/cni/net.d
 ExecStartPre=-/usr/bin/rkt rm --uuid-file=/var/lib/coreos/kubelet-wrapper.uuid
-ExecStartPre=/usr/bin/bash -c \
-  "cat /etc/kubernetes/tls/server/kubelet.crt /etc/kubernetes/tls/ca.pem > /etc/kubernetes/tls/server/kubeletbundle.crt"
+ExecStartPre=/usr/bin/gunzip -r .
+ExecStartPre=/usr/bin/bash -c " \
+  cat tls/server/kubelet.crt tls/ca.pem > tls/server/kubeletbundle.crt && \
+  cat kubeletconfig | jq '.address=\"${COREOS_OPENSTACK_IPV4_LOCAL}\"' > kubeletconfig.tmp && \
+  mv kubeletconfig{.tmp,} \
+  "
 ExecStart=/usr/lib/coreos/kubelet-wrapper \
-  --address=${COREOS_OPENSTACK_IPV4_LOCAL} \
-  --anonymous-auth=false \
-  --authentication-token-webhook \
-  --authorization-mode=Webhook \
-  --client-ca-file=/etc/kubernetes/tls/ca.pem \
-  --cluster-dns=10.0.0.10 \
-  --cluster-domain=cluster.local \
+  --config=/etc/kubernetes/kubeletconfig \
   --kubeconfig=/etc/kubernetes/kubeconfig-kubelet \
   --network-plugin=cni \
-  --node-labels=__NODE_LABELS__ \
-  --pod-manifest-path=/etc/kubernetes/manifests \
-  --read-only-port=0 \
-  --tls-cert-file=/etc/kubernetes/tls/server/kubeletbundle.crt \
-  --tls-private-key-file=/etc/kubernetes/tls/host.key
+  --node-labels=__NODE_LABELS__
 ExecStop=-/usr/bin/rkt stop --uuid-file=/var/lib/coreos/kubelet-wrapper.uuid
 
 [Install]

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ setup(
         'kovh': [
             'data/k8s/*/*.yml',
             'data/k8s/manifests/*.json',
-            'data/k8s/kubeconfig.json',
+            'data/k8s/kube*.json',
             'data/systemd/*.service',
             'data/systemd/*/*.conf'
         ]


### PR DESCRIPTION
Kubernetes 1.12 deprecates most configuration flags and introduces a new way to configure individual components: [Component Configs](https://github.com/kubernetes/community/blob/master/keps/sig-cluster-lifecycle/0014-20180707-componentconfig-api-types-to-staging.md).